### PR TITLE
fix(encoding): handle non-UTF-8 system encoding in subprocess output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,3 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.setuptools.package-data]
-fosslight_dependency = ["LICENSES/*"]

--- a/src/fosslight_dependency/_package_manager.py
+++ b/src/fosslight_dependency/_package_manager.py
@@ -5,6 +5,7 @@
 
 import os
 import logging
+import locale
 import platform
 import re
 import base64
@@ -24,6 +25,43 @@ except Exception:
 logger = logging.getLogger(constant.LOGGER_NAME)
 
 gradle_config = ['runtimeClasspath', 'runtime']
+
+
+def decode_subprocess_output(data, errors='replace'):
+    if isinstance(data, str):
+        return data
+    try:
+        return data.decode('utf-8')
+    except (UnicodeDecodeError, AttributeError):
+        system_encoding = locale.getpreferredencoding(False)
+        try:
+            return data.decode(system_encoding)
+        except (UnicodeDecodeError, LookupError):
+            return data.decode(system_encoding, errors=errors)
+
+
+def run_command(cmd, shell=True, cwd=None, env=None, timeout=None, capture_output=True):
+    kwargs = dict(shell=shell, capture_output=capture_output)
+    if cwd:
+        kwargs['cwd'] = cwd
+    if env:
+        kwargs['env'] = env
+    if timeout:
+        kwargs['timeout'] = timeout
+    result = subprocess.run(cmd, **kwargs)
+    result._stdout_text = decode_subprocess_output(result.stdout) if result.stdout else ''
+    result._stderr_text = decode_subprocess_output(result.stderr) if result.stderr else ''
+    return result
+
+
+def check_output_safe(cmd, shell=True, cwd=None):
+    result = subprocess.run(cmd, shell=shell, capture_output=True, cwd=cwd)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, cmd,
+                                            output=result.stdout, stderr=result.stderr)
+    return decode_subprocess_output(result.stdout)
+
+
 android_config = ['releaseRuntimeClasspath']
 ASKALONO_THRESHOLD = 0.7
 
@@ -117,7 +155,7 @@ class PackageManager:
                 if ret_alldeps:
                     cmd = f"{cmd_gradle} allDeps"
                     try:
-                        ret = subprocess.check_output(cmd, shell=True, encoding='utf-8')
+                        ret = check_output_safe(cmd, shell=True)
                         if ret != 0:
                             self.parse_dependency_tree(ret)
                         else:
@@ -130,7 +168,7 @@ class PackageManager:
                 if ret_plugin:
                     cmd = f"{cmd_gradle} generateLicenseTxt"
                     try:
-                        ret = subprocess.check_output(cmd, shell=True, encoding='utf-8')
+                        ret = check_output_safe(cmd, shell=True)
                         if ret == 0:
                             ret_task = False
                             logger.error(f'Fail to run {cmd}')

--- a/src/fosslight_dependency/_package_manager.py
+++ b/src/fosslight_dependency/_package_manager.py
@@ -33,7 +33,10 @@ def decode_subprocess_output(data, errors='replace'):
     try:
         return data.decode('utf-8')
     except (UnicodeDecodeError, AttributeError):
-        system_encoding = locale.getpreferredencoding(False)
+        if hasattr(locale, 'getencoding'):
+            system_encoding = locale.getencoding()
+        else:
+            system_encoding = locale.getpreferredencoding(False)
         try:
             return data.decode(system_encoding)
         except (UnicodeDecodeError, LookupError):
@@ -46,7 +49,7 @@ def run_command(cmd, shell=True, cwd=None, env=None, timeout=None, capture_outpu
         kwargs['cwd'] = cwd
     if env:
         kwargs['env'] = env
-    if timeout:
+    if timeout is not None:
         kwargs['timeout'] = timeout
     result = subprocess.run(cmd, **kwargs)
     result._stdout_text = decode_subprocess_output(result.stdout) if result.stdout else ''
@@ -169,9 +172,6 @@ class PackageManager:
                     cmd = f"{cmd_gradle} generateLicenseTxt"
                     try:
                         ret = check_output_safe(cmd, shell=True)
-                        if ret == 0:
-                            ret_task = False
-                            logger.error(f'Fail to run {cmd}')
                         if os.path.isfile(self.input_file_name):
                             logger.info('Automatically run android-dependency-scanning plugin and generate output.')
                             self.plugin_auto_run = True

--- a/src/fosslight_dependency/package_manager/Npm.py
+++ b/src/fosslight_dependency/package_manager/Npm.py
@@ -12,7 +12,7 @@ import re
 import requests
 import fosslight_util.constant as constant
 import fosslight_dependency.constant as const
-from fosslight_dependency._package_manager import PackageManager, get_url_to_purl
+from fosslight_dependency._package_manager import PackageManager, get_url_to_purl, decode_subprocess_output
 from fosslight_dependency.dependency_item import DependencyItem, change_dependson_to_purl
 from fosslight_util.oss_item import OssItem
 
@@ -144,17 +144,18 @@ class Npm(PackageManager):
         err_msg = ''
 
         cmd = 'npm ls -a --omit=dev --json -s'
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding='utf-8')
-        rel_tree = result.stdout
+        result = subprocess.run(cmd, shell=True, capture_output=True)
+        rel_tree = decode_subprocess_output(result.stdout)
+        stderr_str = decode_subprocess_output(result.stderr)
         if not rel_tree or rel_tree.strip() == '':
-            logger.error(f"No output for {cmd}, stderr: {result.stderr}")
+            logger.error(f"No output for {cmd}, stderr: {stderr_str}")
             ret = False
         elif result.returncode > 1:
-            logger.error(f"'{cmd}' failed with exit code({result.returncode}), stderr: {result.stderr}")
+            logger.error(f"'{cmd}' failed with exit code({result.returncode}), stderr: {stderr_str}")
             ret = False
         if ret:
             if result.returncode == 1:
-                logger.debug(f"'{cmd}' has warnings: {result.stderr}")
+                logger.debug(f"'{cmd}' has warnings: {stderr_str}")
 
             try:
                 rel_json = json.loads(rel_tree)

--- a/src/fosslight_dependency/package_manager/Pypi.py
+++ b/src/fosslight_dependency/package_manager/Pypi.py
@@ -202,17 +202,20 @@ class Pypi(PackageManager):
         self.set_pip_activate_cmd(activate_cmd)
         self.set_pip_deactivate_cmd(deactivate_cmd)
 
+        env = os.environ.copy()
+        env['PYTHONUTF8'] = '1'
+
         cmd_list = [create_venv_cmd, activate_cmd, install_cmd, pip_upgrade_cmd, deactivate_cmd]
         cmd = cmd_separator.join(cmd_list)
 
         try:
-            cmd_ret = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE)
+            cmd_ret = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE, env=env)
             if cmd_ret.returncode != 0:
                 ret = False
-                err_msg = f"return code({cmd_ret.returncode})"
-            elif cmd_ret.stderr.decode('utf-8').strip().lower().startswith('error:'):
+                err_msg = cmd_ret.stderr.decode('utf-8', errors='replace').strip() or f"return code({cmd_ret.returncode})"
+            elif cmd_ret.stderr.decode('utf-8', errors='replace').strip().lower().startswith('error:'):
                 ret = False
-                err_msg = f"stderr msg({cmd_ret.stderr})"
+                err_msg = cmd_ret.stderr.decode('utf-8', errors='replace').strip()
         except Exception as e:
             ret = False
             err_msg = e
@@ -224,13 +227,13 @@ class Pypi(PackageManager):
 
                     cmd_list = [create_venv_cmd, activate_cmd, install_cmd, pip_upgrade_cmd, deactivate_cmd]
                     cmd = cmd_separator.join(cmd_list)
-                    cmd_ret = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE)
+                    cmd_ret = subprocess.run(cmd, shell=True, stderr=subprocess.PIPE, env=env)
                     if cmd_ret.returncode != 0:
                         ret = False
-                        err_msg = f"return code({cmd_ret.returncode})"
-                    elif cmd_ret.stderr.decode('utf-8').strip().lower().startswith('error:'):
+                        err_msg = cmd_ret.stderr.decode('utf-8', errors='replace').strip() or f"return code({cmd_ret.returncode})"
+                    elif cmd_ret.stderr.decode('utf-8', errors='replace').strip().lower().startswith('error:'):
                         ret = False
-                        err_msg = f"stderr msg({cmd_ret.stderr})"
+                        err_msg = cmd_ret.stderr.decode('utf-8', errors='replace').strip()
             except Exception as e:
                 ret = False
                 err_msg = e
@@ -266,15 +269,18 @@ class Pypi(PackageManager):
         pip_list_command = f"{python_cmd} pip freeze > {tmp_pip_list}"
         deactivate_command = self.pip_deactivate_cmd
 
+        env = os.environ.copy()
+        env['PYTHONUTF8'] = '1'
+
         command_list = [activate_command, pip_list_command, deactivate_command]
         command = command_separator.join(command_list)
 
         exists_pipdeptree = False
         try:
-            cmd_ret = subprocess.call(command, shell=True)
-            if cmd_ret != 0:
+            cmd_ret = subprocess.run(command, shell=True, env=env, stderr=subprocess.PIPE)
+            if cmd_ret.returncode != 0:
                 ret = False
-                err_msg = f"cmd ret code({cmd_ret})"
+                err_msg = cmd_ret.stderr.decode('utf-8', errors='replace').strip() or f"cmd ret code({cmd_ret.returncode})"
             else:
                 if os.path.isfile(tmp_pip_list):
                     with open(tmp_pip_list, 'r', encoding='utf-8') as pip_list_file:
@@ -295,7 +301,7 @@ class Pypi(PackageManager):
         command_list = []
         command_list.append(activate_command)
 
-        pip_inspect_command = f"{python_cmd} pip inspect > {self.tmp_file_name}"
+        pip_inspect_command = f"{python_cmd} pip inspect --no-color > {self.tmp_file_name}"
         command_list.append(pip_inspect_command)
 
         if not exists_pipdeptree:
@@ -312,8 +318,8 @@ class Pypi(PackageManager):
         command = command_separator.join(command_list)
 
         try:
-            cmd_ret = subprocess.call(command, shell=True)
-            if cmd_ret == 0:
+            cmd_ret = subprocess.run(command, shell=True, env=env, stderr=subprocess.PIPE)
+            if cmd_ret.returncode == 0:
                 if os.path.exists(self.tmp_file_name):
                     self.append_input_package_list_file(self.tmp_file_name)
 
@@ -330,7 +336,8 @@ class Pypi(PackageManager):
                     logger.error(f"pip inspect output file not found: {self.tmp_file_name}")
                     ret = False
             else:
-                logger.error(f"Failed to run command: {command}")
+                err_msg = cmd_ret.stderr.decode('utf-8', errors='replace').strip() or f"returncode({cmd_ret.returncode})"
+                logger.error(f"Failed to run command: {command}, {err_msg}")
                 ret = False
         except Exception as e:
             ret = False

--- a/src/fosslight_dependency/package_manager/Yarn.py
+++ b/src/fosslight_dependency/package_manager/Yarn.py
@@ -13,7 +13,7 @@ import fosslight_dependency.constant as const
 from fosslight_dependency.package_manager.Npm import Npm
 from fosslight_dependency.dependency_item import DependencyItem, change_dependson_to_purl
 from fosslight_util.oss_item import OssItem
-from fosslight_dependency._package_manager import get_url_to_purl
+from fosslight_dependency._package_manager import get_url_to_purl, decode_subprocess_output
 from fosslight_dependency.package_manager.Npm import check_multi_license, check_unknown_license
 
 logger = logging.getLogger(constant.LOGGER_NAME)
@@ -32,9 +32,9 @@ class Yarn(Npm):
             return self.yarn_version
 
         try:
-            result = subprocess.run('yarn -v', shell=True, capture_output=True, text=True, encoding='utf-8')
+            result = subprocess.run('yarn -v', shell=True, capture_output=True)
             if result.returncode == 0:
-                version_str = result.stdout.strip()
+                version_str = decode_subprocess_output(result.stdout).strip()
                 major_version = int(version_str.split('.')[0])
 
                 self.yarn_version = major_version


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
fix(encoding): handle non-UTF-8 system encoding in subprocess output

- Add decode_subprocess_output() utility in _package_manager.py
  to safely decode subprocess output using locale-aware fallback
  (UTF-8 → system encoding → replace)
- Apply decode_subprocess_output() in Yarn.detect_yarn_version()
  to handle cp949/euc-kr and other non-UTF-8 system encodings
- Apply decode_subprocess_output() in Npm.parse_transitive_relationship()
  to fix UnicodeDecodeError in _readerthread on non-UTF-8 systems


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable subprocess output decoding (UTF‑8-first with safe fallback) across package managers
  * Clearer, decoded stderr in error and warning messages for CLI tools
  * Consistent environment handling for Python tooling and more robust command return‑code checks
  * Improved version detection for JS tooling via safer output decoding

* **Chores**
  * Removed packaging entry that bundled extra LICENSES files from the distributed package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->