### PR TITLE
Avoid failing when gradlew exists and allDeps input is already present

### DIFF
--- a/src/fosslight_dependency/_package_manager.py
+++ b/src/fosslight_dependency/_package_manager.py
@@ -135,6 +135,7 @@ class PackageManager:
                             ret = subprocess.check_output(cmd, encoding='utf-8')
                             if ret:
                                 self.parse_dependency_tree(ret)
+                                self.set_direct_dependencies(bool(self.direct_dep_list))
                             else:
                                 self.set_direct_dependencies(False)
                                 logger.warning(f"Fail to run {cmd}")
@@ -163,7 +164,7 @@ class PackageManager:
 
             if os.path.isfile(self.input_file_name):
                 logger.info(f'Found {self.input_file_name}, skip to run plugin.')
-                self.set_direct_dependencies(False)
+                self.set_direct_dependencies(bool(self.direct_dep_list))
                 ret_task = True
         except Exception as e:
             logger.error(f'Unexpected error in run_gradle_task: {e}')


### PR DESCRIPTION
## Description
Avoid failing when gradlew exists and allDeps input is already present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed direct-dependency detection when processing Gradle dependency results and when reusing existing dependency output files, so direct dependencies are now reported accurately instead of being incorrectly forced false.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fosslight/fosslight_dependency_scanner/pull/311)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->