### PR TITLE
Strip root path from local package output and add local paths to comments for result file

### DIFF
--- a/src/fosslight_dependency/package_manager/Pub.py
+++ b/src/fosslight_dependency/package_manager/Pub.py
@@ -44,6 +44,39 @@ class Pub(PackageManager):
 
         return True
 
+    def supplement_pkg_details_from_lock(self):
+        lock_file = os.path.join(self.input_dir, 'pubspec.lock')
+        if not os.path.exists(lock_file):
+            return
+        try:
+            with open(lock_file, 'r', encoding='utf-8') as f:
+                lock_data = yaml.safe_load(f)
+            if not lock_data:
+                return
+            packages = lock_data.get('packages', {})
+            for pkg_name, pkg_info in packages.items():
+                source = pkg_info.get('source', '')
+                version = pkg_info.get('version', '')
+                dep_key = f"{pkg_name}({version})"
+                if source == 'path':
+                    if dep_key not in self.pkg_details or not self.pkg_details[dep_key].get('path', ''):
+                        desc = pkg_info.get('description', {})
+                        path = desc.get('path', '') if isinstance(desc, dict) else ''
+                        if dep_key not in self.pkg_details:
+                            self.pkg_details[dep_key] = {}
+                        self.pkg_details[dep_key]['source'] = 'path'
+                        self.pkg_details[dep_key]['path'] = path
+                elif source == 'git':
+                    if dep_key not in self.pkg_details or not self.pkg_details[dep_key].get('url', ''):
+                        desc = pkg_info.get('description', {})
+                        url = desc.get('url', '') if isinstance(desc, dict) else ''
+                        if dep_key not in self.pkg_details:
+                            self.pkg_details[dep_key] = {}
+                        self.pkg_details[dep_key]['source'] = 'git'
+                        self.pkg_details[dep_key]['url'] = url
+        except Exception as e:
+            logger.debug(f'Failed to supplement pkg_details from pubspec.lock: {e}')
+
     def parse_pub_deps_file(self, rel_json):
         try:
             for p in rel_json['packages']:
@@ -154,7 +187,6 @@ class Pub(PackageManager):
                             logger.debug(f"Failed to read pubspec.yaml for {package_name}: {e}")
                             continue
 
-                    # URL 완전 매칭 실패 시 이름만 일치한 디렉터리로 fallback
                     if not package_dir and name_only_match:
                         logger.debug(f"Falling back to name-only match for git package: {package_name}")
                         package_dir = name_only_match
@@ -228,6 +260,7 @@ class Pub(PackageManager):
                         oss_item.license = check_license_name(cache_info['license_text'])
                 else:
                     oss_item.homepage = ''
+                local_path_comment = ''
                 if pkg_source == 'hosted':
                     oss_item.download_location = f"{self.dn_url}{pkg_name}/versions/{version}"
                 elif pkg_source == 'git':
@@ -237,8 +270,20 @@ class Pub(PackageManager):
                         oss_item.download_location = oss_item.homepage
                     oss_item.comment = 'git package'
                 elif pkg_source == 'path':
-                    oss_item.download_location = oss_item.homepage
-                    oss_item.comment = 'local path package'
+                    oss_item.download_location = ''
+                    oss_item.homepage = ''
+                    local_path = ''
+                    if pkg_with_version in self.pkg_details:
+                        raw_path = self.pkg_details[pkg_with_version].get('path', '')
+                        if raw_path:
+                            if not os.path.isabs(raw_path):
+                                local_path = os.path.normpath(os.path.join(self.input_dir, raw_path))
+                            else:
+                                local_path = os.path.normpath(raw_path)
+                    if local_path:
+                        local_path_comment = f'local: {local_path}'
+                    else:
+                        local_path_comment = 'local path package'
                 else:
                     oss_item.download_location = f"{self.dn_url}{pkg_name}/versions/{version}"
                 dep_item.purl = get_url_to_purl(f"{self.dn_url}{pkg_name}/versions/{version}", self.package_manager_name)
@@ -254,6 +299,9 @@ class Pub(PackageManager):
 
                     if pkg_with_version in self.relation_tree:
                         dep_item.depends_on_raw = self.relation_tree[pkg_with_version]
+
+                if local_path_comment:
+                    oss_item.comment = local_path_comment
 
                 dep_item.oss_items.append(oss_item)
                 self.dep_items.append(dep_item)
@@ -329,4 +377,5 @@ class Pub(PackageManager):
 
             except Exception as e:
                 logger.error(f'Fail to run flutter command:{e}')
+        self.supplement_pkg_details_from_lock()
         return True

--- a/src/fosslight_dependency/package_manager/Pypi.py
+++ b/src/fosslight_dependency/package_manager/Pypi.py
@@ -414,10 +414,22 @@ class Pypi(PackageManager):
                 purl_dict[f'{oss_init_name}({oss_item.version})'] = dep_item.purl
 
                 direct_url = package.get('direct_url', {})
+                is_local = False
+                local_path_comment = ''
                 if direct_url:
-                    oss_item.download_location = direct_url.get('url', '')
-                    oss_item.homepage = oss_item.download_location
-                if not package.get('installer', ''):
+                    direct_url_str = direct_url.get('url', '')
+                    if direct_url_str.startswith('file://'):
+                        is_local = True
+                        local_path = direct_url_str[len('file://'):]
+                        local_path = re.sub(r'^/([A-Za-z]:)', r'\1', local_path)
+                        local_path = os.path.normpath(local_path)
+                        oss_item.download_location = ''
+                        oss_item.homepage = ''
+                        local_path_comment = f'local: {local_path}'
+                    else:
+                        oss_item.download_location = direct_url_str
+                        oss_item.homepage = oss_item.download_location
+                if not is_local and not package.get('installer', ''):
                     oss_item.download_location = oss_item.homepage
 
                 if oss_init_name == self.package_name:
@@ -429,6 +441,9 @@ class Pypi(PackageManager):
                         oss_item.comment = 'transitive'
                     if f'{oss_init_name}({oss_item.version})' in self.relation_tree:
                         dep_item.depends_on_raw = self.relation_tree[f'{oss_init_name}({oss_item.version})']
+
+                if local_path_comment:
+                    oss_item.comment = local_path_comment
 
                 dep_item.oss_items.append(oss_item)
                 self.dep_items.append(dep_item)

--- a/src/fosslight_dependency/run_dependency_scanner.py
+++ b/src/fosslight_dependency/run_dependency_scanner.py
@@ -164,8 +164,8 @@ def find_package_manager(input_dir, path_to_exclude=[], manifest_file_name=[], r
     found_package_manager = found_package_manager_bk
 
     if len(found_package_manager) >= 1:
-        log_lines = ["\nDetected Manifest Files automatically"]
-        log_lines = print_package_info(found_package_manager, log_lines)
+        log_lines = [f"\nDetected Manifest Files automatically\nAnalyzed path: {input_dir}"]
+        log_lines = print_package_info(found_package_manager, log_lines, base_dir=input_dir)
         logger.info('\n'.join(log_lines))
     else:
         ret = False
@@ -174,7 +174,7 @@ def find_package_manager(input_dir, path_to_exclude=[], manifest_file_name=[], r
     return ret, found_package_manager, input_dir, suggested_files
 
 
-def print_package_info(pm, log_lines, status=''):
+def print_package_info(pm, log_lines, status='', base_dir=''):
     if pm:
         if status:
             status = f"[{status}] "
@@ -182,7 +182,14 @@ def print_package_info(pm, log_lines, status=''):
             log_lines.append(f"- {status} {pm}:")
             for path, files in dir_dict.items():
                 file_list = ', '.join(files)
-                log_lines.append(f"  {path}: {file_list}")
+                if base_dir:
+                    rel_path = os.path.relpath(path, base_dir)
+                    if rel_path == '.':
+                        log_lines.append(f"  {file_list}")
+                    else:
+                        log_lines.append(f"  {rel_path}{os.sep}{file_list}")
+                else:
+                    log_lines.append(f"  {path}: {file_list}")
     return log_lines
 
 
@@ -261,6 +268,8 @@ def run_dependency_scanner(package_manager='', input_dir='', output_dir_file='',
         input_dir = os.getcwd()
         os.chdir(input_dir)
 
+    base_path = input_dir
+
     autodetect = True
     found_package_manager = {}
     if package_manager:
@@ -282,6 +291,7 @@ def run_dependency_scanner(package_manager='', input_dir='', output_dir_file='',
     else:
         manifest_file_name = []
 
+    suggested_files = []
     try:
         if all_exclude_mode and len(all_exclude_mode) == 4:
             excluded_path_with_default_exclusion, excluded_path_without_dot, excluded_files, _ = all_exclude_mode
@@ -370,9 +380,9 @@ def run_dependency_scanner(package_manager='', input_dir='', output_dir_file='',
     if len(found_package_manager.keys()) > 0:
         log_lines = ["Dependency Analysis Summary"]
         if len(success_pm) > 0:
-            log_lines = print_package_info(success_pm, log_lines, 'Success')
+            log_lines = print_package_info(success_pm, log_lines, 'Success', base_path)
         if len(fail_pm) > 0:
-            log_lines = print_package_info(fail_pm, log_lines, 'Fail')
+            log_lines = print_package_info(fail_pm, log_lines, 'Fail', base_path)
             log_lines.append('If analysis fails, see fosslight_log*.txt and the prerequisite guide: '
                              'https://fosslight.org/fosslight-guide-en/scanner/1_dependency.html#how-to-run-and-output')
         scan_item.set_cover_comment('\n'.join(log_lines))


### PR DESCRIPTION
## Description
Strip root path from local package output and add local paths to comments for result file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better detection and handling of local file dependencies for Python packages.
  * Improved resolution of locally referenced and git-referenced Dart/Flutter packages so package metadata is populated from lockfiles.

* **Improvements**
  * CLI logging and dependency summaries now show relative paths for clearer, consistent output.
  * Local path information is preserved and surfaced as explicit comments in dependency listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fosslight/fosslight_dependency_scanner/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->