### PR TITLE
Handle encoding difference between scanner all and dependency runs

### DIFF
--- a/src/fosslight_dependency/cli.py
+++ b/src/fosslight_dependency/cli.py
@@ -30,9 +30,6 @@ def paginate_file(file_path):
 
 
 def main():
-    os.environ['PYTHONUTF8'] = '1'
-    os.environ['PYTHONIOENCODING'] = 'utf-8'
-
     package_manager = ''
     input_dir = ''
     output_dir = ''

--- a/src/fosslight_dependency/run_dependency_scanner.py
+++ b/src/fosslight_dependency/run_dependency_scanner.py
@@ -197,6 +197,9 @@ def run_dependency_scanner(package_manager='', input_dir='', output_dir_file='',
                            pip_deactivate_cmd='', output_custom_dir='', app_name=const.default_app_name,
                            github_token='', formats=[], direct=True, path_to_exclude=[], graph_path='',
                            graph_size=(600, 600), recursive=False, all_exclude_mode=()):
+    os.environ['PYTHONUTF8'] = '1'
+    os.environ['PYTHONIOENCODING'] = 'utf-8'
+
     global logger
 
     ret = True


### PR DESCRIPTION
## Description
Handle encoding difference between scanner all and dependency runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 encoding handling by ensuring proper initialization during dependency scanning execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->