### PR TITLE
Update GitHub Actions to latest major release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,7 @@ jobs:
   update-changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: main
@@ -56,11 +56,11 @@ jobs:
     needs: update-changelog
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         ref: main
     - name: Set up Python3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install dependencies
@@ -89,11 +89,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         ref: main
     - name: Set up Python3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -102,4 +102,4 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v1
+      uses: fsfe/reuse-action@v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter-config.yml
         env:


### PR DESCRIPTION
Fix a couple of deprecation warnings for Node.js 20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions to enhance compatibility and maintain security standards in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->