### PR TITLE
Use an absolute path for the Gradle wrapper command

### DIFF
--- a/src/fosslight_dependency/_package_manager.py
+++ b/src/fosslight_dependency/_package_manager.py
@@ -130,10 +130,15 @@ class PackageManager:
         return major
 
     def _resolve_wrapper_command(self):
+        # Return an absolute path. The wrapper command is passed to subprocess as a list
+        # with shell=False, and on Windows CreateProcess cannot resolve a bare '.bat'
+        # name, so returning 'gradlew.bat' fails with [WinError 2] on every Windows
+        # machine. An absolute path keeps shell=False (no quoting/injection concerns)
+        # and is equally valid on POSIX.
         if self.platform == const.WINDOWS:
-            return 'gradlew.bat' if os.path.isfile('gradlew.bat') else ''
+            return os.path.abspath('gradlew.bat') if os.path.isfile('gradlew.bat') else ''
         if os.path.isfile('gradlew'):
-            return './gradlew'
+            return os.path.abspath('gradlew')
         return ''
 
     def _run_command_output(self, cmd):
@@ -994,10 +999,12 @@ def get_gradle_cmd():
     current_mode = ''
     changed_mode = False
     if os.path.isfile('gradlew') or os.path.isfile('gradlew.bat'):
+        # Absolute path: the command is run through subprocess with shell=False, and
+        # on Windows CreateProcess cannot resolve a bare '.bat' name ([WinError 2]).
         if platform.system() == const.WINDOWS:
-            cmd_gradle = "gradlew.bat"
+            cmd_gradle = os.path.abspath("gradlew.bat")
         else:
-            cmd_gradle = "./gradlew"
+            cmd_gradle = os.path.abspath("gradlew")
             current_mode, changed_mode = ensure_executable(cmd_gradle)
     return cmd_gradle, current_mode, changed_mode
 

--- a/src/fosslight_dependency/_package_manager.py
+++ b/src/fosslight_dependency/_package_manager.py
@@ -998,12 +998,13 @@ def get_gradle_cmd():
     cmd_gradle = ''
     current_mode = ''
     changed_mode = False
-    if os.path.isfile('gradlew') or os.path.isfile('gradlew.bat'):
-        # Absolute path: the command is run through subprocess with shell=False, and
-        # on Windows CreateProcess cannot resolve a bare '.bat' name ([WinError 2]).
-        if platform.system() == const.WINDOWS:
+    # Absolute path: the command is run through subprocess with shell=False, and
+    # on Windows CreateProcess cannot resolve a bare '.bat' name ([WinError 2]).
+    if platform.system() == const.WINDOWS:
+        if os.path.isfile("gradlew.bat"):
             cmd_gradle = os.path.abspath("gradlew.bat")
-        else:
+    else:
+        if os.path.isfile("gradlew"):
             cmd_gradle = os.path.abspath("gradlew")
             current_mode, changed_mode = ensure_executable(cmd_gradle)
     return cmd_gradle, current_mode, changed_mode


### PR DESCRIPTION
The wrapper command is passed to subprocess as a list with shell=False.
On Windows, CreateProcess cannot resolve a bare '.bat' name, so returning
'gradlew.bat' made every Gradle/Android analysis fail with [WinError 2].

Return os.path.abspath() from both _resolve_wrapper_command() and
get_gradle_cmd(). This keeps shell=False, so there are no quoting or shell
injection concerns, and an absolute path is equally valid on POSIX
(ensure_executable() only stats and chmods the path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gradle wrapper command resolution across Windows and POSIX systems.
  * Prevented failures when invoking the wrapper without relying on shell-based execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->